### PR TITLE
Fixed the `dt` in the burgers data generation script

### DIFF
--- a/data_generation/burgers/burgers1.m
+++ b/data_generation/burgers/burgers1.m
@@ -1,8 +1,9 @@
 function u = burgers1(init, tspan, s, visc)
 
 S = spinop([0 1], tspan);
+dt = tspan(2) - tspan(1);
 S.lin = @(u) + visc*diff(u,2);
 S.nonlin = @(u) - 0.5*diff(u.^2);
 S.init = init;
-u = spin(S,s,1e-4,'plot','off'); 
+u = spin(S,s,dt,'plot','off'); 
 


### PR DESCRIPTION
@zongyi-li 

https://github.com/zongyi-li/fourier_neural_operator/blob/73854fa9bcf75229f2871e0d38b80ac30586859a/data_generation/burgers/burgers1.m#L1-L7

In the Burgers data generation file, `spin` is called with a fixed `dt = 1e-4`. However, it actually should be the time step given by the `tspan`. I know that you are working on cleaning the code, but this PR's change is so minimal that merging with other branches should be no problem after rebasing.