### PR TITLE
Fixed a tiny bug in SpectralConv2d

### DIFF
--- a/fourier_2d.py
+++ b/fourier_2d.py
@@ -53,7 +53,7 @@ class SpectralConv2d(nn.Module):
         x_ft = torch.fft.rfft2(x)
 
         # Multiply relevant Fourier modes
-        out_ft = torch.zeros(batchsize, self.in_channels,  x.size(-2), x.size(-1)//2 + 1, dtype=torch.cfloat, device=x.device)
+        out_ft = torch.zeros(batchsize, self.out_channels,  x.size(-2), x.size(-1)//2 + 1, dtype=torch.cfloat, device=x.device)
         out_ft[:, :, :self.modes1, :self.modes2] = \
             self.compl_mul2d(x_ft[:, :, :self.modes1, :self.modes2], self.weights1)
         out_ft[:, :, -self.modes1:, :self.modes2] = \


### PR DESCRIPTION
https://github.com/zongyi-li/fourier_neural_operator/blob/70f469fef815bad0e07ea4b487b10cdcf3c50b30/fourier_2d.py#L56

The `out_ft` variable should have `out_channels` as the dimension as the complex matmul's output dim is `(B, C_out, W, H)`.

This would pose no change on the current FNO2d net but potentially gives people freedom to use a bottleneck structure.