### PR TITLE
Fixed tensor dimension issue during 1d Burger's prediction

### DIFF
--- a/fourier_1d.py
+++ b/fourier_1d.py
@@ -224,7 +224,7 @@ with torch.no_grad():
         x, y = x.cuda(), y.cuda()
 
         out = model(x)
-        pred[index] = out
+        pred[index] = out.squeeze()
 
         test_l2 += myloss(out.view(1, -1), y.view(1, -1)).item()
         print(index, test_l2)


### PR DESCRIPTION
Fixed the prediction stage of `fourier_1d.py` to return a tensor with all dimensions of size `1` eliminated (using the `squeeze()` method). Without this, it currently returns an error immediately after training and before prediction has started.