### PR TITLE
Update the parameter counting function for complex parameters

### DIFF
--- a/utilities3.py
+++ b/utilities3.py
@@ -305,5 +305,6 @@ class DenseNet(torch.nn.Module):
 def count_params(model):
     c = 0
     for p in list(model.parameters()):
-        c += reduce(operator.mul, list(p.size()))
+        c += reduce(operator.mul, 
+                    list(p.size()+(2,) if p.is_complex() else p.size()))
     return c


### PR DESCRIPTION
Copied the short one-liner from @rgommers 's answer in pytorch/pytorch#57518 .
Basically, one complex parameter is ought to be counted as two real parameters.