### PR TITLE
Fixed the spatial random sampling in UnitGaussianNormalizer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,126 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+pip-wheel-metadata/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py,cover
+.hypothesis/
+.pytest_cache/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+db.sqlite3-journal
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# IPython
+profile_default/
+ipython_config.py
+
+# pyenv
+.python-version
+
+# pipenv
+#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
+#   However, in case of collaboration, if having platform-specific dependencies or dependencies
+#   having no cross-platform support, pipenv may install dependencies that don't work, or not
+#   install all needed dependencies.
+#Pipfile.lock
+
+# PEP 582; used by e.g. github.com/David-OConnor/pyflow
+__pypackages__/
+
+# Celery stuff
+celerybeat-schedule
+celerybeat.pid
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Pyre type checker
+.pyre/

--- a/utilities3.py
+++ b/utilities3.py
@@ -71,33 +71,44 @@ class MatReader(object):
 
 # normalization, pointwise gaussian
 class UnitGaussianNormalizer(object):
-    def __init__(self, x, eps=0.00001):
+    def __init__(self, x, eps=0.00001, time_last=True):
         super(UnitGaussianNormalizer, self).__init__()
 
-        # x could be in shape of ntrain*n or ntrain*T*n or ntrain*n*T
+        # x could be in shape of ntrain*n or ntrain*T*n or ntrain*n*T in 1D
+        # x could be in shape of ntrain*w*l or ntrain*T*w*l or ntrain*w*l*T in 2D
         self.mean = torch.mean(x, 0)
         self.std = torch.std(x, 0)
         self.eps = eps
+        self.time_last = time_last # if the time dimension is the last dim
 
     def encode(self, x):
         x = (x - self.mean) / (self.std + self.eps)
         return x
 
     def decode(self, x, sample_idx=None):
+        # sample_idx is the spatial sampling mask
         if sample_idx is None:
             std = self.std + self.eps # n
             mean = self.mean
         else:
-            if len(self.mean.shape) == len(sample_idx[0].shape):
+            if self.mean.ndim == sample_idx.ndim or self.time_last:
                 std = self.std[sample_idx] + self.eps  # batch*n
                 mean = self.mean[sample_idx]
-            if len(self.mean.shape) > len(sample_idx[0].shape):
-                std = self.std[:,sample_idx]+ self.eps # T*batch*n
-                mean = self.mean[:,sample_idx]
-
-        # x is in shape of batch*n or T*batch*n
+            if self.mean.ndim > sample_idx.ndim and not self.time_last:
+                    std = self.std[...,sample_idx] + self.eps # T*batch*n
+                    mean = self.mean[...,sample_idx]
+        # x is in shape of batch*(spatial discretization size) or T*batch*(spatial discretization size)
         x = (x * std) + mean
         return x
+
+    def to(self, device):
+        if torch.is_tensor(self.mean):
+            self.mean = self.mean.to(device)
+            self.std = self.std.to(device)
+        else:
+            self.mean = torch.from_numpy(self.mean).to(device)
+            self.std = torch.from_numpy(self.std).to(device)
+        return self
 
     def cuda(self):
         self.mean = self.mean.cuda()


### PR DESCRIPTION
In the original repo, `sample_idx` was supposed to be a spatial masking to enable PINN-like loss. However, there is a tiny bug as the mean/std shape can be either in `(T, n, n)` or `(n, n, T)` (default behavior in FNO repo). So an extra switch `self.time_last` is added.

Currently no routine that has `decode` in the current repo uses this arg so it should not affect existing codes.

Also a `.to()` method is added to match the behavior of torch. 